### PR TITLE
Only install enum34 for Python3.4 and under

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     install_requires=[
         'absl-py>=0.1.0',
         'deepdiff',
-        'enum34',
+        'enum34;  python_version <= "3.4"',
         'future',
         'futures; python_version == "2.7"',
         'mock',


### PR DESCRIPTION
On Python 3.7 was hitting,

```
  ERROR: Command errored out with exit status 1:
   command: /Users/julian/src/pymarl/.venv/bin/python3 /Users/julian/src/pymarl/.venv/lib/python3.7/site-packages/pip install --ignore-installed --no-user --prefix /private/var/folders/6b/nc8w6tl142z58_w6zl4v42vw0000gn/T/pip-build-env-0kurykue/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple --extra-index-url https://repo.fury.io/uhB61Gzxe-wPC_6qtvUW/kindred -- 'setuptools>=40.8.0' wheel
       cwd: None
  Complete output (14 lines):
  Traceback (most recent call last):
    File "/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
      "__main__", mod_spec)
    File "/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 85, in _run_code
      exec(code, run_globals)
    File "/Users/julian/src/pymarl/.venv/lib/python3.7/site-packages/pip/__main__.py", line 16, in <module>
      from pip._internal import main as _main  # isort:skip # noqa
    File "/Users/julian/src/pymarl/.venv/lib/python3.7/site-packages/pip/_internal/__init__.py", line 4, in <module>
      import locale
    File "/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/locale.py", line 16, in <module>
      import re
    File "/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/re.py", line 143, in <module>
      class RegexFlag(enum.IntFlag):
  AttributeError: module 'enum' has no attribute 'IntFlag'
```